### PR TITLE
some small changes in books and movies GET endpoints,

### DIFF
--- a/entertainment/routers/utils.py
+++ b/entertainment/routers/utils.py
@@ -137,8 +137,11 @@ def check_country(country: str) -> str | None:
     except LookupError:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Invalid country name. Available country names: %s"
-            % [{country.alpha_2: country.name} for country in pycountry.countries],
+            detail="Invalid country name: '%s'. Available country names: %s"
+            % (
+                country,
+                [{country.alpha_2: country.name} for country in pycountry.countries],
+            ),
         )
 
 
@@ -152,8 +155,8 @@ def check_language(language: str) -> str | None:
     except LookupError:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Invalid language name. Available languages: %s"
-            % [language.name for language in pycountry.languages],
+            detail="Invalid language name: '%s'. Available languages: %s"
+            % (language, [language.name for language in pycountry.languages]),
         )
 
 

--- a/entertainment/tests/routers/test_movies.py
+++ b/entertainment/tests/routers/test_movies.py
@@ -55,6 +55,7 @@ async def test_get_all_movies_200_non_empty_db(async_client: AsyncClient):
     movie3 = create_movie(score=2.7, premiere="2023-03-02", genres="drama")
     expected_result = {
         "number of movies": 3,
+        "page": "1 of 1",
         "movies": [
             jsonable_encoder(movie1),
             jsonable_encoder(movie2),
@@ -82,18 +83,16 @@ async def test_get_all_movies_pagination(async_client: AsyncClient):
 
     # Making the request to the endpoint with page size and page number - empty page
     params = {"page_size": 10, "page_number": 2}
-    expected_result = {
-        "number of movies": 3,
-        "movies": [],
-    }
+    expected_result = "Movies not found."
     response = await async_client.get("/movies/all", params=params)
-    assert response.status_code == 200
-    assert expected_result == response.json()
+    assert response.status_code == 404
+    assert expected_result == response.json()["detail"]
 
     # Making the request to the endpoint with page size and page number - page with movies
     params = {"page_size": 1, "page_number": 3}
     expected_result = {
         "number of movies": 3,
+        "page": "3 of 3",
         "movies": [
             {
                 "id": 3,
@@ -127,12 +126,9 @@ async def test_get_all_movies_pagination(async_client: AsyncClient):
 @pytest.mark.anyio
 async def test_search_movies_empty_db(async_client: AsyncClient):
     response = await async_client.get("/movies/search")
-    expected_result = {
-        "number of movies": 0,
-        "movies": [],
-    }
-    assert response.status_code == 200
-    assert expected_result == response.json()
+    expected_result = "Movies not found."
+    assert response.status_code == 404
+    assert expected_result == response.json()["detail"]
 
 
 @pytest.mark.anyio
@@ -147,6 +143,7 @@ async def test_search_movies_non_empty_db(async_client: AsyncClient):
     )
     expected_result = {
         "number of movies": 1,
+        "page": "1 of 1",
         "movies": [jsonable_encoder(movie1)],
     }
     assert response.status_code == 200
@@ -156,6 +153,7 @@ async def test_search_movies_non_empty_db(async_client: AsyncClient):
     response = await async_client.get("/movies/search", params={"score_ge": 9.0})
     expected_result = {
         "number of movies": 2,
+        "page": "1 of 1",
         "movies": [jsonable_encoder(movie1), jsonable_encoder(movie2)],
     }
     assert response.status_code == 200
@@ -165,6 +163,7 @@ async def test_search_movies_non_empty_db(async_client: AsyncClient):
     response = await async_client.get("/movies/search", params={"title": "movie"})
     expected_result = {
         "number of movies": 3,
+        "page": "1 of 1",
         "movies": [
             jsonable_encoder(movie1),
             jsonable_encoder(movie2),
@@ -180,6 +179,7 @@ async def test_search_movies_non_empty_db(async_client: AsyncClient):
     )
     expected_result = {
         "number of movies": 2,
+        "page": "1 of 1",
         "movies": [
             jsonable_encoder(movie1),
             jsonable_encoder(movie2),
@@ -195,6 +195,7 @@ async def test_search_movies_non_empty_db(async_client: AsyncClient):
     )
     expected_result = {
         "number of movies": 1,
+        "page": "1 of 1",
         "movies": [jsonable_encoder(movie1)],
     }
     assert response.status_code == 200
@@ -202,12 +203,9 @@ async def test_search_movies_non_empty_db(async_client: AsyncClient):
 
     # country == "PL"
     response = await async_client.get("/movies/search", params={"country": "PL"})
-    expected_result = {
-        "number of movies": 0,
-        "movies": [],
-    }
-    assert response.status_code == 200
-    assert expected_result == response.json()
+    expected_result = "Movies not found."
+    assert response.status_code == 404
+    assert expected_result == response.json()["detail"]
 
 
 @pytest.mark.anyio
@@ -220,6 +218,7 @@ async def test_search_movies_pagination(async_client: AsyncClient):
     # Calling the endpoint for the second page with all movies
     expected_result = {
         "number of movies": 11,
+        "page": "2 of 2",
         "movies": [jsonable_encoder(movies[-1])],
     }
     response = await async_client.get(
@@ -229,15 +228,12 @@ async def test_search_movies_pagination(async_client: AsyncClient):
     assert expected_result == response.json()
 
     # Calling the endpoint for the second page with movie title '3 movie'
-    expected_result = {
-        "number of movies": 1,
-        "movies": [],
-    }
+    expected_result = "Movies not found."
     response = await async_client.get(
         "/movies/search", params={"title": "3 movie", "page": 2}
     )
-    assert response.status_code == 200
-    assert expected_result == response.json()
+    assert response.status_code == 404
+    assert expected_result == response.json()["detail"]
 
 
 @pytest.mark.anyio

--- a/entertainment/tests/routers/test_utils.py
+++ b/entertainment/tests/routers/test_utils.py
@@ -243,7 +243,10 @@ def test_check_country_with_invalid_data():
     with pytest.raises(HTTPException) as exc_info:
         check_country("invalid_country")
     assert exc_info.value.status_code == 422
-    assert "Invalid country name. Available country names:" in exc_info.value.detail
+    assert (
+        "Invalid country name: 'invalid_country'. Available country names:"
+        in exc_info.value.detail
+    )
 
 
 def test_check_country_with_empty_data():
@@ -263,7 +266,10 @@ def test_check_language_with_invalid_data():
     with pytest.raises(HTTPException) as exc_info:
         check_language("polnish")
     assert exc_info.value.status_code == 422
-    assert "Invalid language name. Available languages:" in exc_info.value.detail
+    assert (
+        "Invalid language name: 'polnish'. Available languages:"
+        in exc_info.value.detail
+    )
 
 
 def test_check_language_with_empty_data():
@@ -308,7 +314,7 @@ def test_check_language_with_empty_data():
             "orig_lang",
             {"orig_lang": "invalid", "score": 6.6},
             check_language,
-            "Invalid language name. Available languages",
+            "Invalid language name: 'invalid'. Available languages",
         ),
         (
             "country",
@@ -320,7 +326,7 @@ def test_check_language_with_empty_data():
             "country",
             {"country": "invalid", "score": 6.6},
             check_country,
-            "Invalid country name. Available country names",
+            "Invalid country name: 'invalid'. Available country names",
         ),
     ],
 )


### PR DESCRIPTION
Additional response model in routers/books to eliminate null values from GET endpoint response

The same change was not provided in routers/movies GET endpoints because of MovieRequest model fields validation  - issue can be fixed in 2 ways:
1) creating a new response model without field validation and using it for the endpoint
2) adding class variable _validate_fields = True in MovieRequest model and changing responses in validated fields to:
- return check_country(country) if _validate_fields  else country
- return check_language(lang) if _validate_fields  else language
and then in each endpoint with GET placing MovieRequest._validate_fields  = False and in each endpoint with POST, PATCH method placing MovieRequest._validate_fields  = True

For now, in movies we just stick with previous response which returns all model data (with fields with None value as well)