### PR TITLE
search games endpoint updated to include only review_detailed equall …

### DIFF
--- a/entertainment/enums.py
+++ b/entertainment/enums.py
@@ -80,19 +80,38 @@ class GamesReviewOverall(str, Enum):
     POSITIVE = "Positive"
 
 
-class GamesReviewDetailed(str, Enum):
+class GamesReviewDetailed(Enum):
     @classmethod
     def list_of_values(cls):
+        return list(map(lambda c: c.value[1], cls))
+
+    @classmethod
+    def full_values(cls):
         return list(map(lambda c: c.value, cls))
 
-    VERY_NEGATIVE = "Very Negative"
-    NEGATIVE = "Negative"
-    MOSTLY_NEGATIVE = "Mostly Negative"
-    MIXED = "Mixed"
-    MOSTLY_POSITIVE = "Mostly Positive"
-    POSITIVE = "Positive"
-    VERY_POSITIVE = "Very Positive"
-    CRAZY_POSITIVE = "Overwhelmingly Positive"
+    @classmethod
+    def _get_all_exceeding_values(cls, value: str):
+        if value.title() not in cls.list_of_values():
+            raise ValueError(
+                f"The value '{value}' not found in the GamesReviewDetailed class."
+            )
+        list_of_values = []
+        append_to_list = False
+        for element in cls.full_values():
+            if value.title() == element[1]:
+                append_to_list = True
+            if append_to_list:
+                list_of_values.append(element[1])
+        return list_of_values
+
+    VERY_NEGATIVE = 1, "Very Negative"
+    NEGATIVE = 2, "Negative"
+    MOSTLY_NEGATIVE = 3, "Mostly Negative"
+    MIXED = 4, "Mixed"
+    MOSTLY_POSITIVE = 5, "Mostly Positive"
+    POSITIVE = 6, "Positive"
+    VERY_POSITIVE = 7, "Very Positive"
+    CRAZY_POSITIVE = 8, "Overwhelmingly Positive"
 
 
 class EntertainmentCategory(str, Enum):

--- a/entertainment/routers/games.py
+++ b/entertainment/routers/games.py
@@ -131,7 +131,9 @@ async def search_games(
         default=None, enum=["Negative", "Mixed", "Positive"]
     ),
     review_detailed: str | None = Query(
-        default=None, enum=GamesReviewDetailed.list_of_values()
+        default=None,
+        enum=GamesReviewDetailed.list_of_values(),
+        description="The value of detailed review (or any above).",
     ),
     reviews_number: int | None = Query(
         default=None, description="Minimal number of reviews."
@@ -166,7 +168,7 @@ async def search_games(
         "genres",
         "game_type",
         "review_overall",
-        "review_detailed",
+        # "review_detailed",
     ]
     gte_fields = ["reviews_number", "reviews_positive"]
 
@@ -196,6 +198,12 @@ async def search_games(
             if order_type == "descending"
             else games.order_by(order_by)
         )
+
+    if review_detailed:
+        searched_reviews = GamesReviewDetailed._get_all_exceeding_values(
+            review_detailed
+        )
+        games = games.filter(Games.review_detailed.in_(searched_reviews))
 
     results = games.offset((page_number - 1) * 10).limit(10).all()
     logger.debug("Database hits (search games): %s." % len(games.all()))

--- a/entertainment/tests/entertainment/test_enums.py
+++ b/entertainment/tests/entertainment/test_enums.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from entertainment.enums import (
     EntertainmentCategory,
     GamesReviewDetailed,
@@ -18,6 +20,33 @@ def test_games_review_detailed_list_of_values():
     with patch("entertainment.enums.GamesReviewDetailed.list_of_values") as mocked_list:
         mocked_list.return_value = ["a", "b", "c"]
         assert GamesReviewDetailed.list_of_values() == ["a", "b", "c"]
+
+
+def test_games_review_detailed_full_values():
+    partial_result = set(
+        [
+            (1, "Very Negative"),
+            (2, "Negative"),
+            (3, "Mostly Negative"),
+            (4, "Mixed"),
+        ]
+    )
+    assert partial_result <= set(GamesReviewDetailed.full_values())
+
+
+def test_games_review_detailed__get_all_exceeding_values():
+    value = "Positive"
+    exp_result = ["Positive", "Very Positive", "Overwhelmingly Positive"]
+    assert exp_result == GamesReviewDetailed._get_all_exceeding_values(value)
+
+
+def test_games_review_detailed__get_all_exceeding_values_error():
+    value = "Invalid"
+    with pytest.raises(ValueError) as exc_info:
+        GamesReviewDetailed._get_all_exceeding_values(value)
+    assert "The value 'Invalid' not found in the GamesReviewDetailed class." in str(
+        exc_info.value
+    )
 
 
 def test_entertainment_category_list_of_values():

--- a/entertainment/tests/routers/test_games.py
+++ b/entertainment/tests/routers/test_games.py
@@ -218,6 +218,28 @@ async def test_search_games_scenarios(
 
 
 @pytest.mark.anyio
+async def test_search_games_scenarios_review_detailed_test(async_client: AsyncClient):
+    game1 = create_game("Game 1", developer="Ubisoft", review_detailed="Positive")
+    game2 = create_game("New title", review_detailed="Negative")
+    game3 = create_game(publisher="Avalanche", review_detailed="Mostly Positive")
+    game4 = create_game("Test", review_detailed="Very Positive")
+
+    query_params = {"review_detailed": "Positive"}
+    exp_result = {
+        "number_of_games": 2,
+        "page": "1 of 1",
+        "games": [
+            jsonable_encoder(game1, exclude_none=True),
+            jsonable_encoder(game4, exclude_none=True),
+        ],
+    }
+
+    response = await async_client.get("/games/search", params=query_params)
+    assert response.status_code == 200
+    assert response.json() == exp_result
+
+
+@pytest.mark.anyio
 async def test_search_games_pagination(async_client: AsyncClient):
     # Creating 11 gaees in db
     games = []
@@ -340,7 +362,7 @@ async def test_add_game_422_not_unique_game(
         (
             "review_detailed",
             "Very Cool",
-            "Input should be 'Very Negative', 'Negative', 'Mostly Negative'",
+            "Input should be (1, 'Very Negative'), (2, 'Negative'), (3, 'Mostly Negative')",
         ),
         ("reviews_positive", -8, "Input should be greater than or equal to 0"),
     ],
@@ -506,7 +528,7 @@ async def test_update_game_400_if_no_data_to_change(
             {"review_overall": "invalid"},
             "Input should be 'Negative', 'Mixed' or 'Positive'",
         ),
-        ({"review_detailed": "invalid"}, "Input should be 'Very Negative'"),
+        ({"review_detailed": "invalid"}, "Input should be (1, 'Very Negative'), "),
         ({"reviews_positive": 11}, "Input should be less than or equal to 1"),
     ],
 )


### PR DESCRIPTION
…or above selected one

Previously: choosing e.g. 'Positive' as a review_detailed searched field was bound by icontains clause and was looking for all games that had 'Positive' word in review_detailed column (e.g. 'Mostly Positive' was also included in results) while it should search only those records with 'Positive' value of review_detailed  field or any above that (like 'Very Positive' or 'Overwhelmingly Positive').
