### PR TITLE
changes in .env file to include prod env, code fix in other env places

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,10 @@ ALGORITHM=HS256
 
 ENV_STATE=dev
 
+PROD_DATABASE_PATH=entertainment_prod.db
+DEV_DATABASE_PATH=entertainment_dev.db
+TEST_DATABASE_PATH=entertainment_test.db
 
-DEV_DATABASE_PATH=entertainment.db
-TEST_DATABASE_PATH=test.db
-
-DEV_DATABASE_URL=sqlite:///entertainment.db
-TEST_DATABASE_URL=sqlite:///entertainment/tests/test.db
+PROD_DATABASE_URL=sqlite:///entertainment_prod.db
+DEV_DATABASE_URL=sqlite:///entertainment_dev.db
+TEST_DATABASE_URL=sqlite:///entertainment/tests/entertainment_test.db

--- a/entertainment/config.py
+++ b/entertainment/config.py
@@ -2,7 +2,7 @@
 For more flexibility in using application with different environments
 (development, tests or production) we use config.py file together with .env file.
 Depending on the purpose of using the application, change ENV_STATE variable
-in the .env file to either dev or prod.
+in the .env file to either dev or prod or test.
 Tests are automatically set on test state.
 """
 
@@ -33,7 +33,6 @@ class ProdConfig(GlobalConfig):
 
 
 class TestConfig(GlobalConfig):
-    DATABASE_URL: str = "sqlite:///test.db"
     DB_FORCE_ROLL_BACK: bool = True
 
     model_config = SettingsConfigDict(env_prefix="TEST_")

--- a/entertainment/csv_converter.py
+++ b/entertainment/csv_converter.py
@@ -4,11 +4,12 @@
 # inserting the final data to final db tables.
 
 import logging
-import os
 import sqlite3
 
 import chardet
 import pandas as pd
+
+from entertainment.config import config
 
 pd.set_option("display.width", 300)
 pd.set_option("display.max_columns", 15)
@@ -62,7 +63,7 @@ def switch_and_drop_table(table_from: str, table_to: str):
 
 
 # Opening connection to a database
-conn = sqlite3.connect(str(os.environ.get("DEV_DATABASE_PATH")))
+conn = sqlite3.connect(str(config.DATABASE_PATH))
 cursor = conn.cursor()
 
 

--- a/entertainment/tests/conftest.py
+++ b/entertainment/tests/conftest.py
@@ -45,9 +45,6 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 def db_session():
     """Sets a clean db session for each test."""
 
-    Base.metadata.drop_all(bind=engine)
-    Base.metadata.create_all(bind=engine)
-
     db = TestingSessionLocal()
     try:
         yield db


### PR DESCRIPTION
All 3 environments can be in use:
- dev and prod env uses separate database but filled with the same data from csv_converter file
- test env uses empty database for test purposes

NOTE: for Postman code use development database on development environment to test initial db filled with csv data AND use test database on testing development to test empty database